### PR TITLE
#Fixed/TextField,PasswordField

### DIFF
--- a/app/src/main/java/com/tpc/digigate/ui/components/AppTextField.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/components/AppTextField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.tpc.digigate.ui.theme.PureWhite
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppTextField(
     label: String,
@@ -39,6 +40,7 @@ fun AppTextField(
     Column(modifier = modifier.fillMaxWidth()) {
         TextField(
             value = value,
+            textStyle = MaterialTheme.typography.bodyLargeEmphasized,
             onValueChange = onValueChange,
             isError = showError,
             enabled = enabled,
@@ -52,11 +54,11 @@ fun AppTextField(
                 )
                 .padding(vertical = 2.dp),
             shape = RoundedCornerShape(9.dp),
-            label = { Text(text = label, style = MaterialTheme.typography.bodySmall) },
+            label = { Text(text = label, style = MaterialTheme.typography.bodyMedium) },
             placeholder = {
                 Text(
                     text = placeholder,
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyLarge,
                     color = Color.Gray
                 )
             },

--- a/app/src/main/java/com/tpc/digigate/ui/components/AppTextField.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/components/AppTextField.kt
@@ -1,0 +1,123 @@
+package com.tpc.digigate.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.tpc.digigate.ui.theme.PureWhite
+
+@Composable
+fun AppTextField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    errorMessage: String? = null,
+    isSingleLine: Boolean = true,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    imeAction: ImeAction = ImeAction.Done,
+    onImeAction: () -> Unit = {},
+    leadingIcon: (@Composable (() -> Unit))? = null,
+    trailingIcon: (@Composable (() -> Unit))? = null
+) {
+    val isError = !errorMessage.isNullOrEmpty()
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        TextField(
+            value = value,
+            onValueChange = onValueChange,
+            isError = isError,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(PureWhite, RoundedCornerShape(9.dp))
+                .border(
+                    width = 0.6.dp,
+                    color = if (isError) Color.Red else Color.Transparent,
+                    shape = RoundedCornerShape(9.dp)
+                ),
+            shape = RoundedCornerShape(9.dp),
+            label = { Text(text = label) },
+            placeholder = { Text(text = placeholder, modifier = Modifier, Color.LightGray) },
+            singleLine = isSingleLine,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = keyboardType,
+                imeAction = imeAction
+            ),
+            keyboardActions = KeyboardActions(
+                onAny = { onImeAction() }
+            ),
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = PureWhite,
+                unfocusedContainerColor = PureWhite,
+                errorContainerColor = PureWhite,
+
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                errorIndicatorColor = Color.Red,
+
+                focusedLabelColor = if (isError) Color.Red else MaterialTheme.colorScheme.primary,
+                unfocusedLabelColor = if (isError) Color.Red else Color.Gray,
+                errorLabelColor = Color.Red,
+
+                focusedTextColor = Color.LightGray,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                errorTextColor = MaterialTheme.colorScheme.onSurface,
+
+                focusedPlaceholderColor = Color.Gray,
+                unfocusedPlaceholderColor = Color.Gray,
+                errorPlaceholderColor = Color.Red,
+
+                cursorColor = MaterialTheme.colorScheme.primary,
+                errorCursorColor = Color.Red
+            )
+
+        )
+
+        if (isError) {
+            Text(
+                text = errorMessage,
+                color = Color.Red,
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(8.dp), fontSize = 15.sp
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun AppTextFieldPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+
+        MaterialTheme {
+            AppTextField(
+                label = "Email",
+                value = "",
+                onValueChange = {},
+                placeholder = "",
+                errorMessage = "Please enter a valid email id"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/digigate/ui/components/AppTextField.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/components/AppTextField.kt
@@ -11,12 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.tpc.digigate.ui.theme.PureWhite
 
 @Composable
@@ -27,31 +25,41 @@ fun AppTextField(
     modifier: Modifier = Modifier,
     placeholder: String = "",
     errorMessage: String? = null,
+    isError: Boolean = false,
     isSingleLine: Boolean = true,
     keyboardType: KeyboardType = KeyboardType.Text,
     imeAction: ImeAction = ImeAction.Done,
     onImeAction: () -> Unit = {},
     leadingIcon: (@Composable (() -> Unit))? = null,
-    trailingIcon: (@Composable (() -> Unit))? = null
+    trailingIcon: (@Composable (() -> Unit))? = null,
+    enabled: Boolean = true
 ) {
-    val isError = !errorMessage.isNullOrEmpty()
+    val showError = isError && !errorMessage.isNullOrEmpty()
 
     Column(modifier = modifier.fillMaxWidth()) {
         TextField(
             value = value,
             onValueChange = onValueChange,
-            isError = isError,
+            isError = showError,
+            enabled = enabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .background(PureWhite, RoundedCornerShape(9.dp))
                 .border(
-                    width = 0.6.dp,
-                    color = if (isError) Color.Red else Color.Transparent,
+                    width = 1.dp,
+                    color = if (showError) Color.Transparent else Color.Transparent,
                     shape = RoundedCornerShape(9.dp)
-                ),
+                )
+                .padding(vertical = 2.dp),
             shape = RoundedCornerShape(9.dp),
-            label = { Text(text = label) },
-            placeholder = { Text(text = placeholder, modifier = Modifier, Color.LightGray) },
+            label = { Text(text = label, style = MaterialTheme.typography.bodySmall) },
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+            },
             singleLine = isSingleLine,
             keyboardOptions = KeyboardOptions(
                 keyboardType = keyboardType,
@@ -69,36 +77,38 @@ fun AppTextField(
 
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
-                errorIndicatorColor = Color.Red,
+                errorIndicatorColor = Color.Transparent,
 
-                focusedLabelColor = if (isError) Color.Red else MaterialTheme.colorScheme.primary,
-                unfocusedLabelColor = if (isError) Color.Red else Color.Gray,
+                focusedLabelColor = if (showError) Color.Red else MaterialTheme.colorScheme.primary,
+                unfocusedLabelColor = if (showError) Color.Red else Color.Gray,
                 errorLabelColor = Color.Red,
 
-                focusedTextColor = Color.LightGray,
+                focusedTextColor = MaterialTheme.colorScheme.onSurface,
                 unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
                 errorTextColor = MaterialTheme.colorScheme.onSurface,
 
                 focusedPlaceholderColor = Color.Gray,
                 unfocusedPlaceholderColor = Color.Gray,
-                errorPlaceholderColor = Color.Red,
+                errorPlaceholderColor = Color.Gray,
 
                 cursorColor = MaterialTheme.colorScheme.primary,
-                errorCursorColor = Color.Red
-            )
+                errorCursorColor = MaterialTheme.colorScheme.primary,
 
+                errorTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         )
 
-        if (isError) {
+        if (showError) {
             Text(
                 text = errorMessage,
                 color = Color.Red,
-                style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.padding(8.dp), fontSize = 15.sp
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
             )
         }
     }
 }
+
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable

--- a/app/src/main/java/com/tpc/digigate/ui/components/PasswordTextField.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/components/PasswordTextField.kt
@@ -1,0 +1,146 @@
+package com.tpc.digigate.ui.components
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.digigate.ui.theme.PureWhite
+import androidx.compose.ui.Alignment
+
+@Composable
+fun AppPasswordField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String = "",
+    errorMessage: String? = null,
+    isSingleLine: Boolean = true,
+    keyboardType: KeyboardType = KeyboardType.Password,
+    imeAction: ImeAction = ImeAction.Done,
+    onImeAction: () -> Unit = {},
+    isPasswordVisible: Boolean = false,
+    onTogglePasswordVisibility: (() -> Unit)? = null,
+    leadingIcon: (@Composable (() -> Unit))? = null,
+    trailingIcon: (@Composable (() -> Unit))? = null
+) {
+    val isError = !errorMessage.isNullOrEmpty()
+
+    val finalTrailingIcon: @Composable (() -> Unit)? = if (onTogglePasswordVisibility != null) {
+        {
+            val image = if (isPasswordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+            val description = if (isPasswordVisible) "Hide password" else "Show password"
+            IconButton(onClick = onTogglePasswordVisibility) {
+                Icon(imageVector = image, contentDescription = description)
+            }
+        }
+    } else {
+        trailingIcon
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        TextField(
+            value = value,
+            onValueChange = onValueChange,
+            isError = isError,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(PureWhite, RoundedCornerShape(12.dp))
+                .border(
+                    width = 1.dp,
+                    color = if (isError) Color.Red else Color.Transparent,
+                    shape = RoundedCornerShape(12.dp)
+                ),
+            shape = RoundedCornerShape(12.dp),
+            label = { Text(text = label) },
+            placeholder = { Text(text = placeholder) },
+            singleLine = isSingleLine,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = imeAction
+            ),
+            keyboardActions = KeyboardActions(
+                onAny = { onImeAction() }
+            ),
+            visualTransformation = if (isPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            leadingIcon = leadingIcon,
+            trailingIcon = finalTrailingIcon,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = PureWhite,
+                unfocusedContainerColor = PureWhite,
+                errorContainerColor = PureWhite,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                errorIndicatorColor = Color.Red,
+                focusedLabelColor = if (isError) Color.Red else MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedLabelColor = if (isError) Color.Red else MaterialTheme.colorScheme.onSurfaceVariant,
+                errorLabelColor = Color.Red,
+                focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                errorTextColor = MaterialTheme.colorScheme.onSurface,
+                focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                errorPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                cursorColor = MaterialTheme.colorScheme.primary,
+                errorCursorColor = Color.Red,
+                focusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                errorTrailingIconColor = Color.Red
+            )
+        )
+
+        if (isError) {
+            Text(
+                text = errorMessage,
+                color = Color.Red,
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.padding(start = 5.dp, top = 4.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun AppPasswordFieldPreview() {
+
+    MaterialTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            var passwordValue by remember { mutableStateOf("") }
+            var passwordVisible by remember { mutableStateOf(false) }
+
+            AppPasswordField(
+                label = "Password",
+                value = passwordValue,
+                onValueChange = { passwordValue = it },
+                placeholder = "Enter your password",
+                errorMessage = if (passwordValue.length < 8) "Password too short (min 8 chars)" else null,
+                isPasswordVisible = passwordVisible,
+                onTogglePasswordVisibility = { passwordVisible = !passwordVisible }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/digigate/ui/components/PasswordTextField.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/components/PasswordTextField.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.tpc.digigate.ui.theme.PureWhite
 import androidx.compose.ui.Alignment
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppPasswordField(
     label: String,
@@ -60,6 +61,7 @@ fun AppPasswordField(
     Column(modifier = modifier.fillMaxWidth()) {
         TextField(
             value = value,
+            textStyle = MaterialTheme.typography.bodyLargeEmphasized,
             onValueChange = onValueChange,
             isError = showError,
             modifier = Modifier
@@ -70,13 +72,13 @@ fun AppPasswordField(
                     color = if (showError) Color.Transparent else Color.Transparent,
                     shape = RoundedCornerShape(12.dp)
                 )
-                .padding(vertical = 2.dp), // Reduced vertical padding
+                .padding(vertical = 2.dp),
             shape = RoundedCornerShape(12.dp),
-            label = { Text(text = label, style = MaterialTheme.typography.bodySmall) },
+            label = { Text(text = label, style = MaterialTheme.typography.bodyMedium) },
             placeholder = {
                 Text(
                     text = placeholder,
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyLarge,
                     color = Color.Gray
                 )
             },
@@ -129,7 +131,7 @@ fun AppPasswordField(
                 text = errorMessage,
                 color = Color.Red,
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(start = 5.dp, top = 4.dp)
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
             )
         }
     }

--- a/app/src/main/java/com/tpc/digigate/ui/components/PasswordTextField.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/components/PasswordTextField.kt
@@ -33,6 +33,7 @@ fun AppPasswordField(
     modifier: Modifier = Modifier,
     placeholder: String = "",
     errorMessage: String? = null,
+    isError: Boolean = false,
     isSingleLine: Boolean = true,
     keyboardType: KeyboardType = KeyboardType.Password,
     imeAction: ImeAction = ImeAction.Done,
@@ -42,11 +43,11 @@ fun AppPasswordField(
     leadingIcon: (@Composable (() -> Unit))? = null,
     trailingIcon: (@Composable (() -> Unit))? = null
 ) {
-    val isError = !errorMessage.isNullOrEmpty()
+    val showError = isError && !errorMessage.isNullOrEmpty()
 
     val finalTrailingIcon: @Composable (() -> Unit)? = if (onTogglePasswordVisibility != null) {
         {
-            val image = if (isPasswordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+            val image = if (isPasswordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility
             val description = if (isPasswordVisible) "Hide password" else "Show password"
             IconButton(onClick = onTogglePasswordVisibility) {
                 Icon(imageVector = image, contentDescription = description)
@@ -60,58 +61,74 @@ fun AppPasswordField(
         TextField(
             value = value,
             onValueChange = onValueChange,
-            isError = isError,
+            isError = showError,
             modifier = Modifier
                 .fillMaxWidth()
                 .background(PureWhite, RoundedCornerShape(12.dp))
                 .border(
                     width = 1.dp,
-                    color = if (isError) Color.Red else Color.Transparent,
+                    color = if (showError) Color.Transparent else Color.Transparent,
                     shape = RoundedCornerShape(12.dp)
-                ),
+                )
+                .padding(vertical = 2.dp), // Reduced vertical padding
             shape = RoundedCornerShape(12.dp),
-            label = { Text(text = label) },
-            placeholder = { Text(text = placeholder) },
+            label = { Text(text = label, style = MaterialTheme.typography.bodySmall) },
+            placeholder = {
+                Text(
+                    text = placeholder,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+            },
             singleLine = isSingleLine,
             keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
+                keyboardType = keyboardType,
                 imeAction = imeAction
             ),
             keyboardActions = KeyboardActions(
                 onAny = { onImeAction() }
             ),
-            visualTransformation = if (isPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            visualTransformation = if (isPasswordVisible)
+                VisualTransformation.None
+            else
+                PasswordVisualTransformation(mask = '*'),
             leadingIcon = leadingIcon,
             trailingIcon = finalTrailingIcon,
             colors = TextFieldDefaults.colors(
                 focusedContainerColor = PureWhite,
                 unfocusedContainerColor = PureWhite,
                 errorContainerColor = PureWhite,
+
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
-                errorIndicatorColor = Color.Red,
-                focusedLabelColor = if (isError) Color.Red else MaterialTheme.colorScheme.onSurfaceVariant,
-                unfocusedLabelColor = if (isError) Color.Red else MaterialTheme.colorScheme.onSurfaceVariant,
+                errorIndicatorColor = Color.Transparent,
+
+                focusedLabelColor = if (showError) Color.Red else MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedLabelColor = if (showError) Color.Red else MaterialTheme.colorScheme.onSurfaceVariant,
                 errorLabelColor = Color.Red,
+
                 focusedTextColor = MaterialTheme.colorScheme.onSurface,
                 unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
                 errorTextColor = MaterialTheme.colorScheme.onSurface,
+
                 focusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                errorPlaceholderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                errorPlaceholderColor = Color.Gray,
+
                 cursorColor = MaterialTheme.colorScheme.primary,
-                errorCursorColor = Color.Red,
+                errorCursorColor = MaterialTheme.colorScheme.primary,
+
                 focusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                errorTrailingIconColor = Color.Red
+                errorTrailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant
             )
         )
 
-        if (isError) {
+        if (showError) {
             Text(
                 text = errorMessage,
                 color = Color.Red,
-                style = MaterialTheme.typography.labelMedium,
+                style = MaterialTheme.typography.bodySmall,
                 modifier = Modifier.padding(start = 5.dp, top = 4.dp)
             )
         }


### PR DESCRIPTION
@Agrawal-Sujal 
This PR includes the following changes:

Refactored AppTextField to support:

Label inside the TextField

Center alignment in the screen

Error handling with red border and message

Pure white background using PureWhite from colors.kt

Consistent rounded corners for a modern UI look

Added a new PasswordField:
Supports password visibility toggle (eye icon)
Preserves the same styling as Figma

ScreenShot ---->
![image](https://github.com/user-attachments/assets/617e5be2-59df-411b-86a3-660a87524f67)
![image](https://github.com/user-attachments/assets/e201b643-d155-4151-84a7-01ba1c8fee1f)

