### PR TITLE
Added the History Screen Layout

### DIFF
--- a/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,95 +41,20 @@ import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.tpc.digigate.ui.theme.DigiGateTheme
 
 
-data class HistoryCardUiState(
-    val month: String,
-    val date: String,
-    val OutTimeHour: Int,
-    val OutTimeMinute: Int,
-    val OutTimePeriod: String,
-    val InTimeHour: Int,
-    val InTimeMinute: Int,
-    val InTimePeriod: String,
-    val isVerified: Boolean,
-    val year: Int,
-)
-
-val MonthOrder = listOf(
-    "DECEMBER",
-    "NOVEMBER",
-    "OCTOBER",
-    "SEPTEMBER",
-    "AUGUST",
-    "JULY",
-    "JUNE",
-    "MAY",
-    "APRIL",
-    "MARCH",
-    "FEBRUARY",
-    "JANUARY"
-)
-
 @Composable
-fun HistoryScreen(modifier: Modifier = Modifier) {
-    val HistoryItems = remember {
-        listOf(
-            HistoryCardUiState(
-                month = "June",
-                year = 25,
-                date = "15",
-                OutTimeHour = 8,
-                OutTimeMinute = 30,
-                OutTimePeriod = "AM",
-                InTimeHour = 10,
-                InTimeMinute = 40,
-                InTimePeriod = "PM",
-                isVerified = true,
-            ),
-            HistoryCardUiState(
-                month = "June",
-                year = 25,
-                date = "13",
-                OutTimeHour = 10,
-                OutTimeMinute = 30,
-                OutTimePeriod = "AM",
-                InTimeHour = 8,
-                InTimeMinute = 40,
-                InTimePeriod = "PM",
-                isVerified = false,
-            ),
-            HistoryCardUiState(
-                month = "May",
-                year = 25,
-                date = "09",
-                OutTimeHour = 7,
-                OutTimeMinute = 15,
-                OutTimePeriod = "AM",
-                InTimeHour = 6,
-                InTimeMinute = 30,
-                InTimePeriod = "PM",
-                isVerified = true,
-            ),
-            HistoryCardUiState(
-                month = "May",
-                year = 25,
-                date = "25",
-                OutTimeHour = 11,
-                OutTimeMinute = 35,
-                OutTimePeriod = "AM",
-                InTimeHour = 8,
-                InTimeMinute = 15,
-                InTimePeriod = "PM",
-                isVerified = false,
+fun HistoryScreen(viewModel: HistoryViewModel = hiltViewModel()) {
+    val uiState = viewModel.historyUiState.collectAsState().value
+    val MonthData = uiState.historyItems
+        .sortedWith(
+            compareBy(
+                { MonthOrder.indexOf(it.month.uppercase()) },
+                { it.monthData.first().date.toInt() }
             )
         )
-    }
-
-    val MonthData = HistoryItems
-        .sortedWith(compareBy({ MonthOrder.indexOf(it.month.uppercase()) }, { it.date.toInt() }))
-        .groupBy { it.month }
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -150,13 +76,13 @@ fun HistoryScreen(modifier: Modifier = Modifier) {
             modifier = Modifier,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            MonthData.entries.forEachIndexed { index, (month, data) ->
+            MonthData.forEachIndexed { index, data ->
                 item {
                     Box(
                         modifier = Modifier.fillMaxWidth(0.9f),
                     ) {
                         Text(
-                            text = month,
+                            text = data.month,
                             style = MaterialTheme.typography.headlineMedium.copy(
                                 fontWeight = FontWeight.Bold
                             ),
@@ -177,8 +103,11 @@ fun HistoryScreen(modifier: Modifier = Modifier) {
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                 }
-                items(data) { item ->
-                    EntryCard(info = item)
+                items(data.monthData) { item ->
+                    EntryCard(
+                        month = data.month,
+                        info = item
+                    )
                     Spacer(modifier = Modifier.height(20.dp))
                 }
             }
@@ -188,7 +117,8 @@ fun HistoryScreen(modifier: Modifier = Modifier) {
 
 @Composable
 fun EntryCard(
-    info: HistoryCardUiState,
+    month: String,
+    info: HistoryMonthUiState,
 ) {
     Card(
         modifier = Modifier
@@ -220,7 +150,7 @@ fun EntryCard(
                     ),
                 )
                 Text(
-                    text = "${info.month.toString().uppercase()} '${info.year}",
+                    text = "${month.toString().uppercase()} '${info.year}",
                     color = Color.Black,
                     style = MaterialTheme.typography.titleMedium.copy(
                         fontWeight = FontWeight.Bold
@@ -337,12 +267,13 @@ fun LineAndDotImage() {
 fun EntryCardPreview() {
     DigiGateTheme {
         Box(
-            modifier = Modifier.fillMaxWidth().height(140.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(140.dp)
         ) {
             EntryCard(
-                HistoryCardUiState(
-                    month = "MAY",
-                    year = 25,
+                month = "June",
+                info = HistoryMonthUiState(
                     date = "09",
                     OutTimeHour = 7,
                     OutTimeMinute = 15,
@@ -351,7 +282,8 @@ fun EntryCardPreview() {
                     InTimeMinute = 30,
                     InTimePeriod = "PM",
                     isVerified = true,
-                ),
+                    year = 2025
+                )
             )
         }
     }

--- a/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryScreen.kt
@@ -1,9 +1,368 @@
 package com.tpc.digigate.ui.screens.history
 
+import android.content.res.Configuration
+import com.tpc.digigate.R
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.digigate.ui.theme.DigiGateTheme
+
+
+data class HistoryCardUiState(
+    val month: String,
+    val date: String,
+    val OutTimeHour: Int,
+    val OutTimeMinute: Int,
+    val OutTimePeriod: String,
+    val InTimeHour: Int,
+    val InTimeMinute: Int,
+    val InTimePeriod: String,
+    val isVerified: Boolean,
+    val year: Int,
+)
+
+val MonthOrder = listOf(
+    "DECEMBER",
+    "NOVEMBER",
+    "OCTOBER",
+    "SEPTEMBER",
+    "AUGUST",
+    "JULY",
+    "JUNE",
+    "MAY",
+    "APRIL",
+    "MARCH",
+    "FEBRUARY",
+    "JANUARY"
+)
 
 @Composable
-fun HistoryScreen(modifier: Modifier = Modifier){
+fun HistoryScreen(modifier: Modifier = Modifier) {
+    val HistoryItems = remember {
+        listOf(
+            HistoryCardUiState(
+                month = "June",
+                year = 25,
+                date = "15",
+                OutTimeHour = 8,
+                OutTimeMinute = 30,
+                OutTimePeriod = "AM",
+                InTimeHour = 10,
+                InTimeMinute = 40,
+                InTimePeriod = "PM",
+                isVerified = true,
+            ),
+            HistoryCardUiState(
+                month = "June",
+                year = 25,
+                date = "13",
+                OutTimeHour = 10,
+                OutTimeMinute = 30,
+                OutTimePeriod = "AM",
+                InTimeHour = 8,
+                InTimeMinute = 40,
+                InTimePeriod = "PM",
+                isVerified = false,
+            ),
+            HistoryCardUiState(
+                month = "May",
+                year = 25,
+                date = "09",
+                OutTimeHour = 7,
+                OutTimeMinute = 15,
+                OutTimePeriod = "AM",
+                InTimeHour = 6,
+                InTimeMinute = 30,
+                InTimePeriod = "PM",
+                isVerified = true,
+            ),
+            HistoryCardUiState(
+                month = "May",
+                year = 25,
+                date = "25",
+                OutTimeHour = 11,
+                OutTimeMinute = 35,
+                OutTimePeriod = "AM",
+                InTimeHour = 8,
+                InTimeMinute = 15,
+                InTimePeriod = "PM",
+                isVerified = false,
+            )
+        )
+    }
 
+    val MonthData = HistoryItems
+        .sortedWith(compareBy({ MonthOrder.indexOf(it.month.uppercase()) }, { it.date.toInt() }))
+        .groupBy { it.month }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(R.string.history),
+            style = MaterialTheme.typography.displaySmall.copy(
+                fontWeight = FontWeight.ExtraBold
+            ),
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(start = 30.dp)
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        LazyColumn(
+            modifier = Modifier,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            MonthData.entries.forEachIndexed { index, (month, data) ->
+                item {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                    ) {
+                        Text(
+                            text = month,
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontWeight = FontWeight.Bold
+                            ),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            modifier = Modifier.padding(start = 12.dp)
+                        )
+                        if (index == 0) {
+                            Icon(
+                                imageVector = Icons.Outlined.CalendarToday,
+                                contentDescription = stringResource(R.string.calender_today),
+                                tint = MaterialTheme.colorScheme.onBackground,
+                                modifier = Modifier
+                                    .align(Alignment.CenterEnd)
+                                    .padding(end = 10.dp)
+                                    .clickable(onClick = {})
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+                items(data) { item ->
+                    EntryCard(info = item)
+                    Spacer(modifier = Modifier.height(20.dp))
+                }
+            }
+        }
+    }
 }
+
+@Composable
+fun EntryCard(
+    info: HistoryCardUiState,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(0.9f)
+            .border(4.dp, MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(25.dp)),
+        shape = RoundedCornerShape(25.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(
+                modifier = Modifier.padding(start = 4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = info.date,
+                    color = Color.Black,
+                    style = MaterialTheme.typography.displayMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = MaterialTheme.typography.displayMedium.fontSize * 1.2f
+                    ),
+                )
+                Text(
+                    text = "${info.month.toString().uppercase()} '${info.year}",
+                    color = Color.Black,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold
+                    ),
+                    modifier = Modifier.offset(y = -8.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Row(
+                modifier = Modifier,
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                LineAndDotImage()
+                Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    TimeData(
+                        label = stringResource(R.string.out_time),
+                        hour = info.OutTimeHour,
+                        minute = info.OutTimeMinute,
+                        period = info.OutTimePeriod,
+                        isVerified = info.isVerified,
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    TimeData(
+                        label = stringResource(R.string.in_time),
+                        hour = info.InTimeHour,
+                        minute = info.InTimeMinute,
+                        period = info.InTimePeriod,
+                        isVerified = info.isVerified
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+    }
+}
+
+@Composable
+fun TimeData(
+    label: String,
+    hour: Int,
+    minute: Int,
+    period: String,
+    isVerified: Boolean
+) {
+    Column {
+        Text(
+            buildAnnotatedString {
+                withStyle(
+                    style = SpanStyle(
+                        color = Color.Black,
+                        fontSize = MaterialTheme.typography.titleSmall.fontSize * 1.2f,
+                        fontWeight = FontWeight.ExtraBold
+                    )
+                ) {
+                    append("${label}: ${hour}:${minute}")
+                }
+                withStyle(
+                    style = SpanStyle(
+                        color = Color.Black,
+                        fontSize = MaterialTheme.typography.labelSmall.fontSize,
+                        fontWeight = FontWeight.ExtraBold,
+                        baselineShift = BaselineShift.Superscript
+                    )
+                ) {
+                    append(period)
+                }
+            },
+        )
+
+        Text(
+            text = if (isVerified) stringResource(R.string.verified) else stringResource(R.string.not_verified),
+            color = Color.Black,
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontWeight = FontWeight.SemiBold,
+            ),
+            modifier = Modifier.offset(y = -3.dp)
+        )
+    }
+}
+
+
+@Composable
+fun LineAndDotImage() {
+
+    Column(
+        modifier = Modifier.offset(y = -4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(20.dp))
+                .size(12.dp),
+        )
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.primary)
+                .width(2.dp)
+                .height(37.dp),
+        )
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(20.dp))
+                .size(12.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun EntryCardPreview() {
+    DigiGateTheme {
+        Box(
+            modifier = Modifier.fillMaxWidth().height(140.dp)
+        ) {
+            EntryCard(
+                HistoryCardUiState(
+                    month = "MAY",
+                    year = 25,
+                    date = "09",
+                    OutTimeHour = 7,
+                    OutTimeMinute = 15,
+                    OutTimePeriod = "AM",
+                    InTimeHour = 6,
+                    InTimeMinute = 30,
+                    InTimePeriod = "PM",
+                    isVerified = true,
+                ),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun HistoryScreenPreview() {
+    DigiGateTheme {
+        HistoryScreen()
+    }
+}
+

--- a/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryUiState.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryUiState.kt
@@ -1,37 +1,39 @@
 package com.tpc.digigate.ui.screens.history
 
 data class HistoryUiState(
-    val historyItems: List<Month> = emptyList<Month>()
+    val isLoading:Boolean = false,
+    val yearData: List<Year> = emptyList<Year>()
+)
+
+data class Year(
+    val year: Int,
+    val monthData: List<Month> = emptyList<Month>()
 )
 
 data class Month(
-    val month:String = "",
-    val monthData: List<HistoryMonthUiState> = emptyList<HistoryMonthUiState>()
+    val month: Int,
+    val dayEntries: List<DayEntry> = emptyList<DayEntry>()
 )
 
-data class HistoryMonthUiState(
-    val date: String,
-    val OutTimeHour: Int,
-    val OutTimeMinute: Int,
-    val OutTimePeriod: String,
-    val InTimeHour: Int,
-    val InTimeMinute: Int,
-    val InTimePeriod: String,
-    val isVerified: Boolean,
-    val year: Int,
+data class DayEntry(
+    val day: Int,
+    val InTime: String = "",
+    val OutTime: String = "",
+    val isInVerified: Boolean = false,
+    val isOutVerified: Boolean = false
 )
 
-val MonthOrder = listOf(
-    "DECEMBER",
-    "NOVEMBER",
-    "OCTOBER",
-    "SEPTEMBER",
-    "AUGUST",
-    "JULY",
-    "JUNE",
-    "MAY",
-    "APRIL",
-    "MARCH",
-    "FEBRUARY",
-    "JANUARY"
+val MonthOrder = mapOf(
+    1 to "January",
+    2 to "February",
+    3 to "March",
+    4 to "April",
+    5 to "May",
+    6 to "June",
+    7 to "July",
+    8 to "August",
+    9 to "September",
+    10 to "October",
+    11 to "November",
+    12 to "December",
 )

--- a/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryUiState.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryUiState.kt
@@ -1,0 +1,37 @@
+package com.tpc.digigate.ui.screens.history
+
+data class HistoryUiState(
+    val historyItems: List<Month> = emptyList<Month>()
+)
+
+data class Month(
+    val month:String = "",
+    val monthData: List<HistoryMonthUiState> = emptyList<HistoryMonthUiState>()
+)
+
+data class HistoryMonthUiState(
+    val date: String,
+    val OutTimeHour: Int,
+    val OutTimeMinute: Int,
+    val OutTimePeriod: String,
+    val InTimeHour: Int,
+    val InTimeMinute: Int,
+    val InTimePeriod: String,
+    val isVerified: Boolean,
+    val year: Int,
+)
+
+val MonthOrder = listOf(
+    "DECEMBER",
+    "NOVEMBER",
+    "OCTOBER",
+    "SEPTEMBER",
+    "AUGUST",
+    "JULY",
+    "JUNE",
+    "MAY",
+    "APRIL",
+    "MARCH",
+    "FEBRUARY",
+    "JANUARY"
+)

--- a/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryViewModel.kt
@@ -1,0 +1,76 @@
+package com.tpc.digigate.ui.screens.history
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor() : ViewModel() {
+    private val _historyUiState = MutableStateFlow(HistoryUiState())
+    val historyUiState: StateFlow<HistoryUiState> = _historyUiState.asStateFlow()
+
+    init {
+        _historyUiState.update {
+            val month1 = Month(
+                month = "June",
+                monthData = listOf(
+                    HistoryMonthUiState(
+                    year = 25,
+                    date = "15",
+                    OutTimeHour = 8,
+                    OutTimeMinute = 30,
+                    OutTimePeriod = "AM",
+                    InTimeHour = 10,
+                    InTimeMinute = 40,
+                    InTimePeriod = "PM",
+                    isVerified = true,
+                    ),
+                    HistoryMonthUiState(
+                        year = 25,
+                        date = "13",
+                        OutTimeHour = 10,
+                        OutTimeMinute = 30,
+                        OutTimePeriod = "AM",
+                        InTimeHour = 8,
+                        InTimeMinute = 40,
+                        InTimePeriod = "PM",
+                        isVerified = false,
+                    ),
+                )
+            )
+            val month2 = Month(
+                month = "May",
+                monthData = listOf(
+                    HistoryMonthUiState(
+                        year = 25,
+                        date = "09",
+                        OutTimeHour = 7,
+                        OutTimeMinute = 15,
+                        OutTimePeriod = "AM",
+                        InTimeHour = 6,
+                        InTimeMinute = 30,
+                        InTimePeriod = "PM",
+                        isVerified = true,
+                    ),
+                    HistoryMonthUiState(
+                        year = 25,
+                        date = "25",
+                        OutTimeHour = 11,
+                        OutTimeMinute = 35,
+                        OutTimePeriod = "AM",
+                        InTimeHour = 8,
+                        InTimeMinute = 15,
+                        InTimePeriod = "PM",
+                        isVerified = false,
+                    ),
+                )
+            )
+            it.copy(historyItems = listOf(month1,month2))
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/tpc/digigate/ui/screens/history/HistoryViewModel.kt
@@ -16,61 +16,100 @@ class HistoryViewModel @Inject constructor() : ViewModel() {
 
     init {
         _historyUiState.update {
-            val month1 = Month(
-                month = "June",
+            val year1 = Year(
+                year = 2025,
                 monthData = listOf(
-                    HistoryMonthUiState(
-                    year = 25,
-                    date = "15",
-                    OutTimeHour = 8,
-                    OutTimeMinute = 30,
-                    OutTimePeriod = "AM",
-                    InTimeHour = 10,
-                    InTimeMinute = 40,
-                    InTimePeriod = "PM",
-                    isVerified = true,
+                    Month(
+                        month = 8,
+                        dayEntries = listOf(
+                            DayEntry(
+                                day = 9,
+                                OutTime = "7:15 AM",
+                                InTime = "6:30 PM",
+                                isInVerified = true,
+                                isOutVerified = true,
+                            ),
+                            DayEntry(
+                                day = 25,
+                                OutTime = "11:35 AM",
+                                InTime = "8:15 PM",
+                                isInVerified = false,
+                                isOutVerified = true,
+                            ),
+                        )
                     ),
-                    HistoryMonthUiState(
-                        year = 25,
-                        date = "13",
-                        OutTimeHour = 10,
-                        OutTimeMinute = 30,
-                        OutTimePeriod = "AM",
-                        InTimeHour = 8,
-                        InTimeMinute = 40,
-                        InTimePeriod = "PM",
-                        isVerified = false,
+                    Month(
+                        month = 6,
+                        dayEntries = listOf(
+                            DayEntry(
+                                day = 15,
+                                OutTime = "8:30 AM",
+                                InTime = "10:40 PM",
+                                isInVerified = true,
+                                isOutVerified = true,
+                            ),
+                            DayEntry(
+                                day = 13,
+                                OutTime = "10:30 AM",
+                                InTime = "8:40 PM",
+                                isInVerified = true,
+                                isOutVerified = false,
+                            ),
+                            DayEntry(
+                                day = 20,
+                                OutTime = "9:00 AM",
+                                InTime = "7:30 PM",
+                                isInVerified = false,
+                                isOutVerified = false,
+                            ),
+                        )
                     ),
                 )
             )
-            val month2 = Month(
-                month = "May",
+            val year2 = Year(
+                year = 2024,
                 monthData = listOf(
-                    HistoryMonthUiState(
-                        year = 25,
-                        date = "09",
-                        OutTimeHour = 7,
-                        OutTimeMinute = 15,
-                        OutTimePeriod = "AM",
-                        InTimeHour = 6,
-                        InTimeMinute = 30,
-                        InTimePeriod = "PM",
-                        isVerified = true,
+                    Month(
+                        month = 1,
+                        dayEntries = listOf(
+                            DayEntry(
+                                day = 9,
+                                OutTime = "7:15 AM",
+                                InTime = "6:30 PM",
+                                isInVerified = true,
+                                isOutVerified = true,
+                            ),
+                            DayEntry(
+                                day = 25,
+                                OutTime = "11:35 AM",
+                                InTime = "8:15 PM",
+                                isInVerified = false,
+                                isOutVerified = true,
+                            ),
+                        )
                     ),
-                    HistoryMonthUiState(
-                        year = 25,
-                        date = "25",
-                        OutTimeHour = 11,
-                        OutTimeMinute = 35,
-                        OutTimePeriod = "AM",
-                        InTimeHour = 8,
-                        InTimeMinute = 15,
-                        InTimePeriod = "PM",
-                        isVerified = false,
-                    ),
+                    Month(
+                        month = 10,
+                        dayEntries = listOf(
+                            DayEntry(
+                                day = 15,
+                                OutTime = "8:30 AM",
+                                InTime = "10:40 PM",
+                                isInVerified = true,
+                                isOutVerified = true,
+                            ),
+                            DayEntry(
+                                day = 13,
+                                OutTime = "10:30 AM",
+                                InTime = "8:40 PM",
+                                isInVerified = true,
+                                isOutVerified = false,
+                            ),
+                        )
+                    )
                 )
             )
-            it.copy(historyItems = listOf(month1,month2))
+            it.copy(yearData = listOf(year1,year2))
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,10 @@
     <string name="branch">Branch</string>
     <string name="utilities">Utilities</string>
     <string name="view_id_card">View ID Card</string>
+    <string name="calender_today">Calender Today</string>
+    <string name="history">History</string>
+    <string name="verified">VERIFIED</string>
+    <string name="not_verified">NOT VERIFIED</string>
+    <string name="out_time">Out-time</string>
+    <string name="in_time">In-time</string>
 </resources>


### PR DESCRIPTION
## 📝 Overview
-  This PR fixes or fixes part of https://github.com/bsoc-bitbyte/DigiGate/issues/18
- This PR does the following: Implements the history screen based on the provided Figma design , while keeping the colors , theme , fonts and shapes in mind.

---

## ✅ Checklist
- ✅ My code follows the project's style and structure
- ✅ Matches Figma design specifications
- ✅ Tested locally with no errors

---

## 📸 Proof that changes are correct
> - Added screenshots of the history page layout in both light and dark mode respectively.
> - Also the previews for the composable functions implemented inside the HistoryScreen.kt file are made inside the file itself.

![Screenshot 2025-06-20 110033](https://github.com/user-attachments/assets/29ff8c9c-72e7-44a0-90b4-a737ba1f79ea)

---

## 📌 PR Pointers
- If you need a review or an answer to a question, and don't have permissions to assign people, leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL".
- Never force push. If you do, your PR will be closed.

---

## 🗒️ Additional Notes
- Added the required strings in the string.xml file

